### PR TITLE
Integrate pre-commit tool into project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-xml
+      - id: check-added-large-files
+      - id: no-commit-to-branch
+      - id: check-merge-conflict
+      - id: double-quote-string-fixer
+      - id: requirements-txt-fixer
+      - id: check-docstring-first
+      - id: name-tests-test
+      - id: check-ast
+      - id: debug-statements
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.0.1
+    hooks:
+      - id: mypy
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v2.4.0
+    hooks:
+      - id: add-trailing-comma
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.4.2
+    hooks:
+      - id: remove-tabs
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        exclude: ^tests/.*
+  - repo: https://github.com/PyCQA/pylint
+    rev: v2.16.3
+    hooks:
+      - id: pylint
+        args:
+          - --jobs=0
+          - --rcfile=.pylintrc
+          - --output-format=colorized
+          - --score=n
+          - --enable=local
+          - --disable=C0330,R0913,R0914
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8


### PR DESCRIPTION
Settings the pre-commit tool will enable files inspection before committing. The check includes the following:

- maintaining the correctness of workflows with branches in Git (`no-commit-to-branch`, `check-merge-conflict`)
- automatic editing of the most common syntax errors (`add-trailing-comma`, `remove-tabs,` `trailing-whitespace`, `double-quote-string-fixer`)
- enforcing coding standards and best practices (`check-docstring-first`, `end-of-file-fixer`, `check-ast`, `name-tests-test`)
- checking for file formats (`check-yaml`, `check-xml`)
- linters (`flake8`, `pydocstyle`, `pylint`, `mypy`)

More details at [https://pre-commit.com/hooks.html](https://pre-commit.com/hooks.html)

Resolves #12




