### PR TITLE
Add integration with GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: 🧪
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linters:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Fetch the src
+      uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install pre-commit
+      run: python -m pip install --upgrade pre-commit
+
+    - name: Run pre-commit
+      run: python -m pre_commit run --all-files
+      env:
+        SKIP: no-commit-to-branch

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![🧪 CI/CD](https://github.com/kpi-web-guild/OlenaEfymenko/actions/workflows/ci.yml/badge.svg)](https://github.com/kpi-web-guild/django-girls-blog-OlenaEfymenko/actions/workflows/ci.yml?query=branch%3Amain)
+
 ## **Introduction**
 
 Educational project within IT KPI Python mentorship program by @webknjaz.


### PR DESCRIPTION
Integration of CI/CD configuration into the project enables the running pre-commit tool. It provides fixing errors and following the best practices in the project. Setting up the badge into project README enables to display the current status of this workflow.

Resolves #14

