### PR TITLE
Correct the broken badge image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![🧪 CI/CD](https://github.com/kpi-web-guild/OlenaEfymenko/actions/workflows/ci.yml/badge.svg)](https://github.com/kpi-web-guild/django-girls-blog-OlenaEfymenko/actions/workflows/ci.yml?query=branch%3Amain)
+[![🧪 CI/CD](https://github.com/kpi-web-guild/django-girls-blog-OlenaEfymenko/actions/workflows/ci.yml/badge.svg)](https://github.com/kpi-web-guild/django-girls-blog-OlenaEfymenko/actions/workflows/ci.yml?query=branch%3Amain)
 
 ## **Introduction**
 


### PR DESCRIPTION
This patch makes the CI badge in README render properly, as the previous image link had a typo causing it not to show up at all.