### PR TITLE
Update flake8 to 6.1.0 version in pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     - --disable=C0330,R0913,R0914
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 6.1.0
   hooks:
   - id: flake8
 


### PR DESCRIPTION
Upgrade to the latest version to take advantage of new linting features.