### PR TITLE
Add flake8 plugin to assess cognitive complexity

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+
+# Let's not overcomplicate the code:
+max-complexity = 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,8 @@ repos:
   rev: 6.1.0
   hooks:
   - id: flake8
+    additional_dependencies:
+    - flake8-cognitive-complexity ~= 0.1.0
 
 - repo: https://github.com/adrienverge/yamllint.git
   rev: v1.32.0


### PR DESCRIPTION
This PR adds tools for analyzing cyclomatic and cognitive complexities in repo. This includes flake8 and wily.

Ref #18