### PR TITLE
Integrate Codecov code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
     - name: Run tests
       run: python -m manage test
 
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+
   linters:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This patch adds the `Codecov` tool to automatically track test coverage.
It provides a detailed coverage metric for testing in the project.

Related #18 