### PR TITLE
☂️ Extend coverage measurement tool for the project

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ skip_covered = false
 [report]
 skip_covered = true
 show_missing = true
+fail_under = 100
 exclude_also =
   \#.*no cover
   \s*raise AssertionError\b
@@ -22,4 +23,8 @@ relative_files = true
 source =
   tests
 source_pkgs =
+  blog
   mysite
+omit =
+    mysite/asgi.py
+    mysite/wsgi.py

--- a/manage.py
+++ b/manage.py
@@ -21,6 +21,12 @@ def coverage_context():
         yield
     cov.save()
     print(f'Coverage is {cov.report()}%')
+
+    covered = cov.report()
+    fail_under = cov.config.get_option('report:fail_under')
+    if covered < fail_under:
+        raise SystemExit(2)
+
     cov.html_report()
     cov.xml_report()
 


### PR DESCRIPTION
This patch adds the blog application to the coverage measurement configuration, providing total test coverage for the project. It also improves the configuration by omitting unnecessary files from the report and setting up the fail_under value.

Ref #18 