### PR TITLE
Improve code coverage reports with added logs and fixed HTML/XML generation

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -22,13 +22,13 @@ def coverage_context():
     cov.save()
     print(f'Coverage is {cov.report()}%')
 
+    cov.html_report()
+    cov.xml_report()
+
     covered = cov.report()
     fail_under = cov.config.get_option('report:fail_under')
     if covered < fail_under:
         raise SystemExit(2)
-
-    cov.html_report()
-    cov.xml_report()
 
 
 @contextmanager

--- a/manage.py
+++ b/manage.py
@@ -28,6 +28,10 @@ def coverage_context():
 
     fail_under = cov.config.get_option('report:fail_under')
     if covered < fail_under:
+        print(
+            'Erroring out because the coverage level is lower '
+            f'than the mandatory of {fail_under !s}%...',
+        )
         raise SystemExit(2)
 
 

--- a/manage.py
+++ b/manage.py
@@ -21,10 +21,13 @@ def coverage_context():
         yield
     cov.save()
     covered = cov.report()
-    print(f'Coverage is {covered}%')
+    print(f'Coverage is {covered}%\n')
 
     cov.html_report()
+    print(f'Coverage HTML was written to dir {cov.config.html_dir}\n')
+
     cov.xml_report()
+    print(f'Coverage XML was written to file {cov.config.xml_output}\n')
 
     fail_under = cov.config.get_option('report:fail_under')
     if covered < fail_under:

--- a/manage.py
+++ b/manage.py
@@ -20,12 +20,12 @@ def coverage_context():
     with cov.collect():
         yield
     cov.save()
-    print(f'Coverage is {cov.report()}%')
+    covered = cov.report()
+    print(f'Coverage is {covered}%')
 
     cov.html_report()
     cov.xml_report()
 
-    covered = cov.report()
     fail_under = cov.config.get_option('report:fail_under')
     if covered < fail_under:
         raise SystemExit(2)


### PR DESCRIPTION
- Change condition of generation HTML report for review coverage analysis;
- Fix double output in the `coverage` report;
- Add logs for HTML and XML reports generation and configured `fail_under`;

Ref #18 